### PR TITLE
#16 Welcome to Laminas and bye bye to Zend Framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,13 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.2
+    - php: 7.3
       env:
         - EXECUTE_TEST_COVERALLS=true
-    - php: 7
+    - php: 7.4
       env:
         - EXECUTE_CS_CHECK=true
-    - php: 7.1
-    - php: hhvm
-  allow_failures:
-    - php: 7.1
-    - php: hhvm
 
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All Notable changes to `svycka/sv-settings` will be documented in this file
 ## NEXT - YYYY-MM-DD
 
 ### Added
-- Nothing
+- Added Laminas support
+- Added PHP 7.3 and PHP 7.4 support
 
 ### Deprecated
 - Nothing
@@ -14,7 +15,8 @@ All Notable changes to `svycka/sv-settings` will be documented in this file
 - Nothing
 
 ### Removed
-- Nothing
+- [BC Break] Removed Zend Framework support(just renamed to Laminas)
+- Removed PHP 5.6, 7.0 and 7.1 support
 
 ### Security
 - Nothing

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "zendframework",
         "doctrine",
         "zf2",
-        "module"
+        "module",
+        "Laminas"
     ],
     "homepage": "https://github.com/svycka/sv-settings",
     "license": "MIT",
@@ -20,27 +21,27 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "zendframework/zend-modulemanager": "^2.6.1",
-        "zendframework/zend-servicemanager": "^3.1.1",
-        "zendframework/zend-stdlib": "^3.1",
-        "zendframework/zend-i18n": "^2.6",
-        "zendframework/zend-validator": "^2.5.2"
+        "php": "^7.2",
+        "laminas/laminas-i18n": "^2.6",
+        "laminas/laminas-modulemanager": "^2.6.1",
+        "laminas/laminas-servicemanager": "^3.1.1",
+        "laminas/laminas-stdlib": "^3.1",
+        "laminas/laminas-validator": "^2.5.2",
+        "phpunit/phpunit": "^7.5.20"
     },
     "require-dev": {
         "doctrine/doctrine-orm-module": "^1.1",
-        "zendframework/zend-router": "^3.0.2",
-        "zendframework/zend-mvc": "^3.0.3",
-        "zendframework/zend-view": "^2.5.2",
-        "zfcampus/zf-api-problem": "^1.2",
-        "phpunit/phpunit": "^5.6.4",
-        "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "^2.5"
+        "laminas/laminas-router": "^3.0.2",
+        "laminas/laminas-mvc": "^3.0.3",
+        "laminas/laminas-view": "^2.5.2",
+        "laminas-api-tools/api-tools-api-problem": "^1.2",
+        "scrutinizer/ocular": "^1.6.0",
+        "squizlabs/php_codesniffer": "^3.5.3"
     },
     "suggest": {
-        "zendframework/zend-mvc": "Required, if you will use SettingsApiController",
-        "zendframework/zend-view": "Required, if you will use SettingsApiController",
-        "zfcampus/zf-api-problem": "Required, if you will use SettingsApiController",
+        "laminas/laminas-mvc": "Required, if you will use SettingsApiController",
+        "laminas/laminas-view": "Required, if you will use SettingsApiController",
+        "laminas-api-tools/api-tools-api-problem": "Required, if you will use SettingsApiController",
         "doctrine/doctrine-orm-module": "Required, if you will use Doctrine for settings storage"
     },
     "autoload": {
@@ -58,5 +59,17 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "scripts": {
+        "check": [
+            "@test",
+            "@cs-check"
+        ],
+        "cs-check": "php vendor/bin/phpcs",
+        "cs-fix": "php vendor/bin/phpcbf",
+        "test": "php vendor/bin/phpunit --colors=always"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/src/Collection/CollectionsManager.php
+++ b/src/Collection/CollectionsManager.php
@@ -4,7 +4,7 @@ namespace Svycka\Settings\Collection;
 
 use Interop\Container\ContainerInterface;
 use Svycka\Settings\Collection\Factory\SettingsCollectionAbstractFactory;
-use Zend\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\AbstractPluginManager;
 
 /**
  * Class CollectionsManager

--- a/src/Collection/Factory/SettingsCollectionAbstractFactory.php
+++ b/src/Collection/Factory/SettingsCollectionAbstractFactory.php
@@ -11,9 +11,9 @@ use Svycka\Settings\Options\ModuleOptions;
 use Svycka\Settings\Provider\OwnerProviderInterface;
 use Svycka\Settings\Storage\StorageAdapterInterface;
 use Svycka\Settings\Type\TypesManager;
-use Zend\ServiceManager\Factory\AbstractFactoryInterface;
-use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Controller/SettingsApiController.php
+++ b/src/Controller/SettingsApiController.php
@@ -5,12 +5,12 @@ namespace Svycka\Settings\Controller;
 use Svycka\Settings\Collection\CollectionInterface;
 use Svycka\Settings\Collection\CollectionsManager;
 use Svycka\Settings\Exception\SettingDoesNotExistException;
-use Zend\Mvc\Controller\AbstractRestfulController;
-use Zend\Mvc\MvcEvent;
-use Zend\Stdlib\ArrayUtils;
-use Zend\View\Model\JsonModel;
-use ZF\ApiProblem\ApiProblem;
-use ZF\ApiProblem\ApiProblemResponse;
+use Laminas\Mvc\Controller\AbstractRestfulController;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Stdlib\ArrayUtils;
+use Laminas\View\Model\JsonModel;
+use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings;
 
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Options/CollectionOptions.php
+++ b/src/Options/CollectionOptions.php
@@ -4,7 +4,7 @@ namespace Svycka\Settings\Options;
 
 use Svycka\Settings\Entity\Setting;
 use Svycka\Settings\Provider\NullProvider;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Options/ModuleOptions.php
+++ b/src/Options/ModuleOptions.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\I18n\Validator\IsFloat;
+use Laminas\I18n\Validator\IsFloat;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/InArrayType.php
+++ b/src/Type/InArrayType.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\Validator\InArray;
+use Laminas\Validator\InArray;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\I18n\Validator\IsInt;
+use Laminas\I18n\Validator\IsInt;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/RegexType.php
+++ b/src/Type/RegexType.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\Validator\Regex;
+use Laminas\Validator\Regex;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -2,7 +2,7 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\Validator\StringLength;
+use Laminas\Validator\StringLength;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/src/Type/TypesManager.php
+++ b/src/Type/TypesManager.php
@@ -2,9 +2,9 @@
 
 namespace Svycka\Settings\Type;
 
-use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\Exception\InvalidServiceException;
-use Zend\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Laminas\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Class TypesManager

--- a/tests/Settings/Collection/CollectionsManagerTest.php
+++ b/tests/Settings/Collection/CollectionsManagerTest.php
@@ -10,16 +10,16 @@ use Svycka\Settings\Provider\NullProvider;
 use Svycka\Settings\Storage\MemoryStorage;
 use Svycka\Settings\Type\TypesManager;
 use TestAssets\CustomCollection;
-use Zend\ServiceManager\Exception\InvalidServiceException;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class CollectionsManagerTest extends \PHPUnit_Framework_TestCase
+class CollectionsManagerTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanAddCustomType()
     {

--- a/tests/Settings/Collection/Factory/CollectionsManagerFactoryTest.php
+++ b/tests/Settings/Collection/Factory/CollectionsManagerFactoryTest.php
@@ -11,7 +11,7 @@ use Svycka\Settings\Options\ModuleOptions;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class CollectionsManagerFactoryTest extends \PHPUnit_Framework_TestCase
+class CollectionsManagerFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Collection/SettingsCollectionTest.php
+++ b/tests/Settings/Collection/SettingsCollectionTest.php
@@ -13,13 +13,13 @@ use Svycka\Settings\Storage\StorageAdapterInterface;
 use Svycka\Settings\Storage\MemoryStorage;
 use Svycka\Settings\Type\TypesManager;
 use TestAssets\UserCollectionOptions;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingsCollectionTest extends \PHPUnit_Framework_TestCase
+class SettingsCollectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var CollectionInterface
@@ -48,6 +48,8 @@ class SettingsCollectionTest extends \PHPUnit_Framework_TestCase
         $types_manager = new TypesManager(new ServiceManager(), []);
 
         new SettingsCollection($options, $adapter, $owner_provider, $types_manager);
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function testCanGetSetValue()

--- a/tests/Settings/Controller/Factory/SettingsApiControllerFactoryTest.php
+++ b/tests/Settings/Controller/Factory/SettingsApiControllerFactoryTest.php
@@ -6,13 +6,13 @@ use Interop\Container\ContainerInterface;
 use Svycka\Settings\Collection\CollectionsManager;
 use Svycka\Settings\Controller\Factory\SettingsApiControllerFactory;
 use Svycka\Settings\Controller\SettingsApiController;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingsApiControllerFactoryTest extends \PHPUnit_Framework_TestCase
+class SettingsApiControllerFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Controller/SettingsApiControllerTest.php
+++ b/tests/Settings/Controller/SettingsApiControllerTest.php
@@ -8,21 +8,21 @@ use Svycka\Settings\Controller\SettingsApiController;
 use Svycka\Settings\Exception\SettingDoesNotExistException;
 use Svycka\Settings\Options\ModuleOptions;
 use TestAssets\CustomCollection;
-use Zend\Http\Header\GenericHeader;
-use Zend\Http\Request;
-use Zend\Http\Response;
-use Zend\Mvc\MvcEvent;
-use Zend\Router\RouteMatch;
-use Zend\ServiceManager\ServiceManager;
-use Zend\Stdlib\Parameters;
-use Zend\View\Model\JsonModel;
-use ZF\ApiProblem\ApiProblemResponse;
+use Laminas\Http\Header\GenericHeader;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Router\RouteMatch;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Stdlib\Parameters;
+use Laminas\View\Model\JsonModel;
+use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 
 /**
  * @author  Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingsApiControllerFactoryTest extends \PHPUnit_Framework_TestCase
+class SettingsApiControllerFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /** @var SettingsApiController */
     private $controller;

--- a/tests/Settings/Entity/SettingTest.php
+++ b/tests/Settings/Entity/SettingTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Entity\Setting;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingTest extends \PHPUnit_Framework_TestCase
+class SettingTest extends \PHPUnit\Framework\TestCase
 {
     /** @var Setting */
     private $setting;

--- a/tests/Settings/ModuleTest.php
+++ b/tests/Settings/ModuleTest.php
@@ -4,7 +4,7 @@ namespace Svycka\SettingsTest;
 
 use Svycka\Settings\Module;
 
-class ModuleTest extends \PHPUnit_Framework_TestCase
+class ModuleTest extends \PHPUnit\Framework\TestCase
 {
     public function testConfigIsArray()
     {

--- a/tests/Settings/Options/CollectionOptionsTest.php
+++ b/tests/Settings/Options/CollectionOptionsTest.php
@@ -11,7 +11,7 @@ use Svycka\Settings\Storage\MemoryStorage;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class CollectionOptionsTest extends \PHPUnit_Framework_TestCase
+class CollectionOptionsTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CollectionOptions */
     private $options;

--- a/tests/Settings/Options/Factory/ModuleOptionsFactoryTest.php
+++ b/tests/Settings/Options/Factory/ModuleOptionsFactoryTest.php
@@ -4,13 +4,13 @@ namespace Svycka\SettingsTest\Options\Factory;
 
 use Svycka\Settings\Options\Factory\ModuleOptionsFactory;
 use Svycka\Settings\Options\ModuleOptions;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class ModuleOptionsFactoryTest extends \PHPUnit_Framework_TestCase
+class ModuleOptionsFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Options/ModuleOptionsTest.php
+++ b/tests/Settings/Options/ModuleOptionsTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Options\ModuleOptions;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class ModuleOptionsTest extends \PHPUnit_Framework_TestCase
+class ModuleOptionsTest extends \PHPUnit\Framework\TestCase
 {
     /** @var ModuleOptions */
     private $options;

--- a/tests/Settings/Provider/NullProviderTest.php
+++ b/tests/Settings/Provider/NullProviderTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Provider\NullProvider;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class NullProviderTest extends \PHPUnit_Framework_TestCase
+class NullProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanGetIdentifier()
     {

--- a/tests/Settings/Service/Factory/SettingsServiceFactoryTest.php
+++ b/tests/Settings/Service/Factory/SettingsServiceFactoryTest.php
@@ -6,13 +6,13 @@ use Interop\Container\ContainerInterface;
 use Svycka\Settings\Collection\CollectionsManager;
 use Svycka\Settings\Service\Factory\SettingsServiceFactory;
 use Svycka\Settings\Service\SettingsService;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingsServiceFactoryTest extends \PHPUnit_Framework_TestCase
+class SettingsServiceFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Service/SettingsServiceTest.php
+++ b/tests/Settings/Service/SettingsServiceTest.php
@@ -6,14 +6,14 @@ use Svycka\Settings\Collection\CollectionInterface;
 use Svycka\Settings\Collection\CollectionsManager;
 use Svycka\Settings\Service\SettingsService;
 use TestAssets\CustomCollection;
-use Zend\ServiceManager\Config;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\Config;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class SettingsServiceTest extends \PHPUnit_Framework_TestCase
+class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 {
     /** @var SettingsService */
     private $service;

--- a/tests/Settings/Storage/DoctrineStorageTest.php
+++ b/tests/Settings/Storage/DoctrineStorageTest.php
@@ -15,7 +15,7 @@ use TestAssets\CustomCollection;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class DoctrineStorageTest extends \PHPUnit_Framework_TestCase
+class DoctrineStorageTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CollectionInterface */
     private $collection;

--- a/tests/Settings/Storage/Factory/DoctrineStorageFactoryTest.php
+++ b/tests/Settings/Storage/Factory/DoctrineStorageFactoryTest.php
@@ -5,13 +5,13 @@ namespace Svycka\SettingsTest\Storage\Factory;
 use Doctrine\ORM\EntityManagerInterface;
 use Svycka\Settings\Storage\DoctrineStorage;
 use Svycka\Settings\Storage\Factory\DoctrineStorageFactory;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class DoctrineStorageFactoryTest extends \PHPUnit_Framework_TestCase
+class DoctrineStorageFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Storage/MemoryStorageTest.php
+++ b/tests/Settings/Storage/MemoryStorageTest.php
@@ -10,7 +10,7 @@ use TestAssets\CustomCollection;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class MemoryStorageTest extends \PHPUnit_Framework_TestCase
+class MemoryStorageTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CollectionInterface */
     private $collection;

--- a/tests/Settings/Type/AbstractSettingTypeTest.php
+++ b/tests/Settings/Type/AbstractSettingTypeTest.php
@@ -10,7 +10,7 @@ use TestAssets\CustomAbstractSettingType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class AbstractSettingTypeTest extends \PHPUnit_Framework_TestCase
+class AbstractSettingTypeTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CustomAbstractSettingType */
     private $type;

--- a/tests/Settings/Type/Factory/TypesManagerFactoryTest.php
+++ b/tests/Settings/Type/Factory/TypesManagerFactoryTest.php
@@ -5,13 +5,13 @@ namespace Svycka\SettingsTest\Type\Factory;
 use Svycka\Settings\Options\ModuleOptions;
 use Svycka\Settings\Type\Factory\TypesManagerFactory;
 use Svycka\Settings\Type\TypesManager;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class TypesManagerFactoryTest extends \PHPUnit_Framework_TestCase
+class TypesManagerFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanCreate()
     {

--- a/tests/Settings/Type/FloatTypeTest.php
+++ b/tests/Settings/Type/FloatTypeTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Type\FloatType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class FloatTypeTest extends \PHPUnit_Framework_TestCase
+class FloatTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanValidate()
     {

--- a/tests/Settings/Type/InArrayTypeTest.php
+++ b/tests/Settings/Type/InArrayTypeTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Type\InArrayType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class InArrayTypeTest extends \PHPUnit_Framework_TestCase
+class InArrayTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanValidate()
     {

--- a/tests/Settings/Type/IntegerTypeTest.php
+++ b/tests/Settings/Type/IntegerTypeTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Type\IntegerType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class IntegerTypeTest extends \PHPUnit_Framework_TestCase
+class IntegerTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanValidate()
     {

--- a/tests/Settings/Type/RegexTypeTest.php
+++ b/tests/Settings/Type/RegexTypeTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Type\RegexType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class RegexTypeTest extends \PHPUnit_Framework_TestCase
+class RegexTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanValidate()
     {

--- a/tests/Settings/Type/StringTypeTest.php
+++ b/tests/Settings/Type/StringTypeTest.php
@@ -8,7 +8,7 @@ use Svycka\Settings\Type\StringType;
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class StringTypeTest extends \PHPUnit_Framework_TestCase
+class StringTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanValidate()
     {

--- a/tests/Settings/Type/TypesManagerTest.php
+++ b/tests/Settings/Type/TypesManagerTest.php
@@ -9,15 +9,15 @@ use Svycka\Settings\Type\RegexType;
 use Svycka\Settings\Type\StringType;
 use Svycka\Settings\Type\TypesManager;
 use TestAssets\CustomSettingType;
-use Zend\ServiceManager\Exception\InvalidServiceException;
-use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
  * @license MIT
  */
-class TypesManagerTest extends \PHPUnit_Framework_TestCase
+class TypesManagerTest extends \PHPUnit\Framework\TestCase
 {
     public function testHasDefaultTypes()
     {

--- a/tests/TestAssets/CustomCollection.php
+++ b/tests/TestAssets/CustomCollection.php
@@ -9,7 +9,7 @@ use Svycka\Settings\Provider\OwnerProviderInterface;
 use Svycka\Settings\Storage\MemoryStorage;
 use Svycka\Settings\Storage\StorageAdapterInterface;
 use Svycka\Settings\Type\TypesManager;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>

--- a/tests/TestAssets/UserCollectionOptions.php
+++ b/tests/TestAssets/UserCollectionOptions.php
@@ -7,7 +7,7 @@ use Svycka\Settings\Options\CollectionOptionsInterface;
 use Svycka\Settings\Provider\NullProvider;
 use Svycka\Settings\Storage\MemoryStorage;
 use Svycka\Settings\Type\InArrayType;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * @author Vytautas Stankus <svycka@gmail.com>
@@ -25,7 +25,7 @@ class UserCollectionOptions extends AbstractOptions implements CollectionOptions
             'type'          => 'inarray',
             'options'       => [
                 'haystack' => ['C', 'F'],
-                'strict'   => \Zend\Validator\InArray::COMPARE_STRICT,
+                'strict'   => \Laminas\Validator\InArray::COMPARE_STRICT,
             ]
         ],
         'distance_unit'    => [
@@ -36,7 +36,7 @@ class UserCollectionOptions extends AbstractOptions implements CollectionOptions
                 'haystack' => [
                     'km', 'm', 'mi', 'yd',
                 ],
-                'strict'   => \Zend\Validator\InArray::COMPARE_STRICT,
+                'strict'   => \Laminas\Validator\InArray::COMPARE_STRICT,
             ]
         ],
         'locale'           => [


### PR DESCRIPTION
- [x] Added Laminas support
- [x]  Added PHP 7.3 and PHP 7.4 support
- [x] [BC Break] Removed Zend Framework support(just renamed to Laminas)
- [x] Removed PHP 5.6, 7.0 and 7.1 support

closes #16 