### PR TITLE
fixed: Calling Doctrine\ORM\EntityManager::flush() with any arguments…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All Notable changes to `svycka/sv-settings` will be documented in this file
 - Nothing
 
 ### Fixed
-- Nothing
+- [BC Break] Will call flush() on Doctrine entityManager without specific entity because it is deprecated
 
 ### Removed
 - Nothing

--- a/src/Storage/DoctrineStorage.php
+++ b/src/Storage/DoctrineStorage.php
@@ -64,7 +64,7 @@ final class DoctrineStorage implements StorageAdapterInterface
         $setting->setValue($value);
 
         $this->entityManager->persist($setting);
-        $this->entityManager->flush($setting);
+        $this->entityManager->flush();
     }
 
     /**

--- a/tests/Settings/Storage/DoctrineStorageTest.php
+++ b/tests/Settings/Storage/DoctrineStorageTest.php
@@ -55,7 +55,7 @@ class DoctrineStorageTest extends \PHPUnit\Framework\TestCase
         );
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->persist($entity)->shouldBeCalled();
-        $entityManager->flush($entity)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
         $repository = $this->prophesize(ObjectRepository::class);
         $repository->findOneBy([
             'collection' => $this->collection->getOptions()->getName(),
@@ -74,7 +74,7 @@ class DoctrineStorageTest extends \PHPUnit\Framework\TestCase
         $setting->setValue($value = 'F')->shouldBeCalled();
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->persist($setting->reveal())->shouldBeCalled();
-        $entityManager->flush($setting->reveal())->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
 
         $repository = $this->prophesize(ObjectRepository::class);
         $repository->findOneBy([


### PR DESCRIPTION
… to flush specific entities is deprecated and will not be supported in Doctrine ORM 3.0.